### PR TITLE
Add flatland creature guessing game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # flatland-viewer
+
+Simple web-based game where you guess the number of sides of a Flatland creature.
+A polygon with 3-10 sides is rendered on a canvas, and edges farther from the viewer fade into white fog.
+Enter your guess and see if you are correct.
+
+Open `index.html` in a browser to play.

--- a/game.js
+++ b/game.js
@@ -1,0 +1,58 @@
+const canvas = document.getElementById('creature');
+const ctx = canvas.getContext('2d');
+let currentSides = 3;
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateCreature() {
+  currentSides = randomInt(3, 10);
+  const angleOffset = Math.random() * Math.PI * 2;
+  const radius = 150;
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.lineWidth = 4;
+  ctx.lineCap = 'round';
+
+  const points = [];
+  for (let i = 0; i < currentSides; i++) {
+    const angle = angleOffset + (i / currentSides) * Math.PI * 2;
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
+    points.push({ x, y });
+  }
+
+  const ys = points.map(p => p.y);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+
+  for (let i = 0; i < currentSides; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % currentSides];
+    const midY = (p1.y + p2.y) / 2;
+    const t = (maxY - midY) / (maxY - minY); // 0 near, 1 far
+    const grey = Math.round(255 * t);
+    ctx.strokeStyle = `rgb(${grey},${grey},${grey})`;
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.stroke();
+  }
+}
+
+document.getElementById('submit').addEventListener('click', () => {
+  const guess = parseInt(document.getElementById('guess').value, 10);
+  const feedback = document.getElementById('feedback');
+  if (guess === currentSides) {
+    feedback.textContent = `Correct! It was a ${currentSides}-sided creature.`;
+  } else {
+    feedback.textContent = `Incorrect. It was a ${currentSides}-sided creature.`;
+  }
+  generateCreature();
+});
+
+// Start game
+generateCreature();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Flatland Viewer</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; }
+    canvas { border: 1px solid #ccc; margin-bottom: 1em; }
+    #feedback { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Guess the Flatland Creature</h1>
+  <canvas id="creature" width="400" height="400"></canvas>
+  <div>
+    <input type="number" id="guess" min="3" max="10" placeholder="3-10" />
+    <button id="submit">Guess</button>
+  </div>
+  <div id="feedback"></div>
+  <script src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement canvas-based game that draws a 3-10 sided Flatland creature with white fog on distant edges
- Provide input for guessing the number of sides and feedback after each guess
- Document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a00d92136c83299c98d6a2e9e60a08