### PR TITLE
Add flatland creature guessing game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # flatland-viewer
+
+Simple web-based game where you guess the number of sides of a Flatland creature.
+The creature is rendered as if viewed from the side: all edges collapse into a single vertical line and only
+the white "fog" on distant edges hints at the true number of sides.
+Enter your guess and see if you are correct.
+
+Open `index.html` in a browser to play.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # flatland-viewer
 
 Simple web-based game where you guess the number of sides of a Flatland creature.
-The creature is rendered as if viewed from the side: all edges collapse into a single vertical line and only
-the white "fog" on distant edges hints at the true number of sides.
+The creature is rendered as if viewed from the side: all edges collapse into a single horizontal line that spins once per second, and only the white "fog" on distant edges hints at the true number of sides.
 Enter your guess and see if you are correct.
 
 Open `index.html` in a browser to play.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # flatland-viewer
 
 Simple web-based game where you guess the number of sides of a Flatland creature.
-The creature is rendered as if viewed from the side: all edges collapse into a single horizontal line that spins once per second, and only the white "fog" on distant edges hints at the true number of sides.
+The creature is rendered as if viewed from the side: all edges collapse into a single horizontal line that spins once every ten seconds, and only the white "fog" on distant edges hints at the true number of sides.
 Enter your guess and see if you are correct.
 
 Open `index.html` in a browser to play.

--- a/game.js
+++ b/game.js
@@ -1,0 +1,67 @@
+const canvas = document.getElementById('creature');
+const ctx = canvas.getContext('2d');
+let currentSides = 3;
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateCreature() {
+  currentSides = randomInt(3, 10);
+  const angleOffset = Math.random() * Math.PI * 2;
+  const radius = 150;
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.lineWidth = 8;
+  ctx.lineCap = 'round';
+
+  // Create polygon points centered at origin so we can project onto a side view.
+  const points = [];
+  for (let i = 0; i < currentSides; i++) {
+    const angle = angleOffset + (i / currentSides) * Math.PI * 2;
+    const x = radius * Math.cos(angle);
+    const y = radius * Math.sin(angle);
+    points.push({ x, y });
+  }
+
+  const xs = points.map(p => p.x);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+
+  const edges = [];
+  for (let i = 0; i < currentSides; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % currentSides];
+    const avgX = (p1.x + p2.x) / 2;
+    edges.push({ p1, p2, avgX });
+  }
+
+  // Draw from farthest to nearest so closer edges occlude distant ones.
+  edges.sort((a, b) => b.avgX - a.avgX);
+
+  for (const { p1, p2, avgX } of edges) {
+    const t = (avgX - minX) / (maxX - minX); // 0 near, 1 far
+    const grey = Math.round(255 * t);
+    ctx.strokeStyle = `rgb(${grey},${grey},${grey})`;
+    ctx.beginPath();
+    ctx.moveTo(centerX, centerY + p1.y);
+    ctx.lineTo(centerX, centerY + p2.y);
+    ctx.stroke();
+  }
+}
+
+document.getElementById('submit').addEventListener('click', () => {
+  const guess = parseInt(document.getElementById('guess').value, 10);
+  const feedback = document.getElementById('feedback');
+  if (guess === currentSides) {
+    feedback.textContent = `Correct! It was a ${currentSides}-sided creature.`;
+  } else {
+    feedback.textContent = `Incorrect. It was a ${currentSides}-sided creature.`;
+  }
+  generateCreature();
+});
+
+// Start game
+generateCreature();

--- a/game.js
+++ b/game.js
@@ -32,7 +32,7 @@ function drawCreature() {
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.lineWidth = 40; // five times thicker line
-  ctx.lineCap = 'round';
+  ctx.lineCap = 'butt'; // flat line ends for vertical edges
 
   const rotated = points.map(p => ({
     x: p.x * Math.cos(rotation) - p.y * Math.sin(rotation),
@@ -68,7 +68,7 @@ function animate(timestamp) {
   if (!lastTime) lastTime = timestamp;
   const delta = (timestamp - lastTime) / 1000; // seconds
   lastTime = timestamp;
-  rotation += delta * 2 * Math.PI; // one rotation per second
+  rotation += delta * 2 * Math.PI / 10; // one rotation every ten seconds
   drawCreature();
   requestAnimationFrame(animate);
 }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Flatland Viewer</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; }
+    canvas { border: 1px solid #ccc; margin-bottom: 1em; }
+    #feedback { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Guess the Flatland Creature</h1>
+  <p>The creature is viewed from the side—only the white fog reveals distant edges.</p>
+  <canvas id="creature" width="400" height="400"></canvas>
+  <div>
+    <input type="number" id="guess" min="3" max="10" placeholder="3-10" />
+    <button id="submit">Guess</button>
+  </div>
+  <div id="feedback"></div>
+  <script src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Draw Flatland creature from side view so only white fog hints at its number of sides
- Explain side-view fog mechanic in page and documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a00d92136c83299c98d6a2e9e60a08